### PR TITLE
Implementar recurso de pesquisa

### DIFF
--- a/app/src/main/java/com/carolinabarrossilva/nihongo/data/Searcher.kt
+++ b/app/src/main/java/com/carolinabarrossilva/nihongo/data/Searcher.kt
@@ -1,6 +1,4 @@
-package com.carolinabarrossilva.nihongo.model
-
-import com.carolinabarrossilva.nihongo.data.Term
+package com.carolinabarrossilva.nihongo.data
 
 data class Searcher(val terms: List<Term>) {
     private infix fun Term.hasEnglishDefinitionsFor(search: String): Boolean {

--- a/app/src/main/java/com/carolinabarrossilva/nihongo/data/Searcher.kt
+++ b/app/src/main/java/com/carolinabarrossilva/nihongo/data/Searcher.kt
@@ -1,0 +1,20 @@
+package com.carolinabarrossilva.nihongo.model
+
+import com.carolinabarrossilva.nihongo.data.Term
+
+data class Searcher(val terms: List<Term>) {
+    private infix fun Term.hasEnglishDefinitionsFor(search: String): Boolean {
+        return englishDefinitions.any { definition ->
+            definition.contains(search, ignoreCase = true)
+        }
+    }
+
+    infix fun searchFor(search: String): List<Term> {
+        return when {
+            search.isNotBlank() ->
+                terms.filter { term -> term.word.contains(search, ignoreCase = true) || term hasEnglishDefinitionsFor search }
+            else ->
+                terms
+        }
+    }
+}

--- a/app/src/main/java/com/carolinabarrossilva/nihongo/ui/Search.kt
+++ b/app/src/main/java/com/carolinabarrossilva/nihongo/ui/Search.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
 import com.carolinabarrossilva.nihongo.data.Term
-import com.carolinabarrossilva.nihongo.model.Searcher
+import com.carolinabarrossilva.nihongo.data.Searcher
 import com.carolinabarrossilva.nihongo.ui.component.TermCard
 import com.carolinabarrossilva.nihongo.ui.theme.NihongoTheme
 

--- a/app/src/main/java/com/carolinabarrossilva/nihongo/ui/Search.kt
+++ b/app/src/main/java/com/carolinabarrossilva/nihongo/ui/Search.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
 import com.carolinabarrossilva.nihongo.data.Term
+import com.carolinabarrossilva.nihongo.model.Searcher
 import com.carolinabarrossilva.nihongo.ui.component.TermCard
 import com.carolinabarrossilva.nihongo.ui.theme.NihongoTheme
 
@@ -28,8 +29,9 @@ private fun SearchPreview() {
 
 @Composable
 fun Search(modifier: Modifier = Modifier) {
+    val searcher = remember { Searcher(Term.samples) }
     var search by remember { mutableStateOf("") }
-    val terms = Term.samples
+    val terms by derivedStateOf { searcher searchFor search }
 
     Surface(
         Modifier.fillMaxSize(),


### PR DESCRIPTION
A classe `Searcher` recebe alguns termos (`terms`) e pesquisa por eles a partir da função `searchFor`. Toda vez que o usuário digita algo no campo de pesquisa, o texto é passado à essa função como sendo o parâmetro `search`.

- Declaração da função na classe `Searcher`:
```kotlin
infix fun searchFor(search: String): List<Term> {
    return when {
        search.isNotBlank() ->
            terms.filter { term -> term.word.contains(search, ignoreCase = true) || term hasEnglishDefinitionsFor search }
        else ->
            terms
    }
}
```
- Chamada à função na interface:
```kotlin
val searcher = remember { Searcher(Term.samples) }
var search by remember { mutableStateOf("") }
val terms by derivedStateOf { searcher searchFor search }
```

Nesse último caso, a variável `searcher` "lembra", a cada atualização da tela, do objeto `Searcher` que foi criado; a variável `search` é o texto que o usuário digita no campo de pesquisa; e a variável `terms` são os termos encontrados com base na pesquisa do usuário, que chama a função `searchFor` do `searcher`.

Não é o modo mais eficiente, mas está bom para o que temos por agora. 🙂